### PR TITLE
Add HP OMEN Transcend 16 8C4D fan support

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ This program also includes a modification that sets the max speed according to c
 
 *   **Model:** HP OMEN MAX 16-AH0001NT (8D41)
 *   **OS:** Arch Linux 6.18, 6.19, 7.0
+*   **Model:** HP OMEN Transcend 16-u1xxx (8C4D)
+*   **OS:** Arch Linux 6.18 LTS, 7.0
 
 ## Installation
 

--- a/hp-wmi.c
+++ b/hp-wmi.c
@@ -378,6 +378,10 @@ static const struct dmi_system_id
             .driver_data = (void *)&omen_v1_thermal_params,
         },
         {
+            .matches = {DMI_MATCH(DMI_BOARD_NAME, "8C4D")},
+            .driver_data = (void *)&omen_v1_thermal_params,
+        },
+        {
             .matches = {DMI_MATCH(DMI_BOARD_NAME, "8C99")},
             .driver_data = (void *)&victus_s_thermal_params,
         },

--- a/omen_logic.py
+++ b/omen_logic.py
@@ -56,7 +56,7 @@ SUPPORTED_BOARDS = {
     
     "88F8", "8A25",
     "8BAB", "8BBE", "8BCA", "8BD4", "8BD5", "8C76", "8C77", "8C78", "8BCD",
-    "8C99", "8C9C", "8D41", "8D87", "8A44", "8A4D", "8C58", "8BA9"
+    "8C4D", "8C99", "8C9C", "8D41", "8D87", "8A44", "8A4D", "8C58", "8BA9"
 }
 
 POSSIBLY_SUPPPORTED_OMEN_BOARDS = {
@@ -69,7 +69,7 @@ POSSIBLY_SUPPPORTED_OMEN_BOARDS = {
     "8912", "8917", "8918", "8A97", "8A96", "8D2C", "8949", "8A98", "894A",
     "8B1D", "89EB", "8A4C", "8A4D", "8A4E", "8A40", "8A41", "8A42", "8A43",
     "8A44", "8BA8", "8BA9", "8BAA", "8BAC", "8C76", "8C77", "8C78",
-    "8BCA", "8BCB", "8BCF", "8C9B", "8BB3", "8BB4", "8C4D", "8C4E",
+    "8BCA", "8BCB", "8BCF", "8C9B", "8BB3", "8BB4", "8C4E",
     "8C58", "8C75", "8C74", "8C73", "8CC1", "8CC0", "8CF1", "8CF2", "8CF3",
     "8CF4", "8D2F"
 }


### PR DESCRIPTION
I tested this on an HP OMEN Transcend 16 with board ID `8C4D`. The board was already listed as a possible OMEN board, but the legacy OMEN profile path did not actually change fan speed for me.

Using the Victus S fan-control path with `omen_v1_thermal_params` does work: the driver exposes the hwmon PWM controls, and writing fan values changes the real fan RPM. This PR moves `8C4D` from the possible board list to the supported board list and adds it to the same thermal-parameter table.

Tested by:

- building `hp-wmi.ko` against Arch Linux 6.18 LTS headers
- loading the patched driver
- checking that hwmon PWM controls are present
- manually changing fan values and confirming that RPM changes
