### PR TITLE
EC 0xEC fan boost fallback for legacy OMEN 15 (84DA/84DB/84DC)

### DIFF
--- a/omen_logic.py
+++ b/omen_logic.py
@@ -74,6 +74,10 @@ POSSIBLY_SUPPPORTED_OMEN_BOARDS = {
     "8CF4", "8D2F"
 }
 
+# Legacy OMEN 15 (2018-2019): WMI pwm1_enable max fails; EC 0xEC boost works.
+EC_FAN_BOOST_BOARDS = {"84DA", "84DB", "84DC"}
+EC_FAN_BOOST_OFFSET = 0xEC
+
 class FanController:
     def __init__(self, config_path=None):
         self._find_paths()
@@ -209,6 +213,27 @@ class FanController:
         with open(target_path, "w") as f:
             json.dump(self.config, f, indent=4)
 
+    def uses_ec_fan_boost(self):
+        status, board = self.check_board_support()
+        return board in EC_FAN_BOOST_BOARDS
+
+    def _ec_fan_boost_set(self, enabled):
+        try:
+            subprocess.run(["modprobe", "ec_sys", "write_support=1"], check=True,
+                           capture_output=True)
+        except subprocess.CalledProcessError as e:
+            print(f"Failed to load ec_sys: {e}")
+            return False
+        ecio = "/sys/kernel/debug/ec/ec0/io"
+        try:
+            with open(ecio, "r+b") as ec:
+                ec.seek(EC_FAN_BOOST_OFFSET)
+                ec.write(bytes([1 if enabled else 0]))
+            return True
+        except Exception as e:
+            print(f"Error writing EC fan boost: {e}")
+            return False
+
     def write_sys_file(self, path, value):
         """Helper to write to sysfs files."""
         if not path:
@@ -303,6 +328,12 @@ class FanController:
 
     def set_fan_mode(self, mode):
         """Sets fan mode: 'max', 'auto', or 'manual'."""
+        if self.uses_ec_fan_boost():
+            if mode == 'max':
+                self._ec_fan_boost_set(True)
+            elif mode == 'auto':
+                self._ec_fan_boost_set(False)
+            return
         if mode == 'max':
             self.write_sys_file(self.pwm1_enable_path, 0)
         elif mode == 'auto':


### PR DESCRIPTION
## Summary

Board `84DB` is listed as **SUPPORTED**, but fan max via `pwm1_enable=0` fails on stock kernel `7.0.0-27-generic` (WMI query `0x27` → EINVAL). RPM readback and auto mode work.

Tested workaround on **OMEN 15-dc0xxx**:
- EC offset `0xEC`, write `1` = max (~4600/5300 RPM)
- write `0` = restore auto

This PR routes `set_fan_mode('max'/'auto')` through EC boost on boards `84DA`/`84DB`/`84DC` instead of broken WMI max path.

## Why not only the hp-wmi kernel patch?

The Victus S driver patch in this project does not cover `84D*` boards (they are absent from `victus_s_thermal_profile_boards[]`). EC fallback is the working userspace path today.

## Test plan

- [x] `omen_cli.py status` on 84DB
- [x] `fan-control --mode max` via EC → RPM increase
- [x] `fan-control --mode auto` → restore
- [ ] Calibration max RPM on 84DB with EC path

## References

https://github.com/murilopontes/hp-omen-fan-linux