### PR TITLE
Fix fan-table parsing regressions vs upstream; add OMEN 16-ap0xxx (8D26) support

### DIFF
--- a/hp-wmi.c
+++ b/hp-wmi.c
@@ -397,6 +397,11 @@ static const struct dmi_system_id
             .matches = {DMI_MATCH(DMI_BOARD_NAME, "8D41")},
             .driver_data = (void *)&victus_s_thermal_params,
         },
+        {
+            /* OMEN 16-ap0xxx: V1 profile values, legacy EC readback */
+            .matches = {DMI_MATCH(DMI_BOARD_NAME, "8D26")},
+            .driver_data = (void *)&omen_v1_legacy_thermal_params,
+        },
         {},
 };
 
@@ -2500,10 +2505,15 @@ static int hp_wmi_hwmon_read(struct device *dev, enum hwmon_sensor_types type,
   priv = dev_get_drvdata(dev);
   switch (type) {
   case hwmon_fan:
-    if (is_victus_s_thermal_profile())
+    if (is_victus_s_thermal_profile()) {
       ret = hp_wmi_get_fan_speed_victus_s(channel);
-    else
+      /* Boards like 8D26 answer the victus_s query with zeros while
+         the legacy query reports true tach values - fall back. */
+      if (ret == 0)
+        ret = hp_wmi_get_fan_speed(channel);
+    } else {
       ret = hp_wmi_get_fan_speed(channel);
+    }
     if (ret < 0)
       return ret;
     *val = ret;
@@ -2512,6 +2522,8 @@ static int hp_wmi_hwmon_read(struct device *dev, enum hwmon_sensor_types type,
     if (attr == hwmon_pwm_input) {
       if (is_victus_s_thermal_profile()) {
         rpm = hp_wmi_get_fan_speed_victus_s(channel);
+        if (rpm == 0)
+          rpm = hp_wmi_get_fan_speed(channel);
         if (rpm < 0)
           return rpm;
         *val = rpm_to_pwm(rpm / 100, priv);
@@ -2566,6 +2578,8 @@ static int hp_wmi_hwmon_write(struct device *dev, enum hwmon_sensor_types type,
        */
       if (is_victus_s_thermal_profile()) {
         rpm = hp_wmi_get_fan_speed_victus_s(channel);
+        if (rpm == 0)
+          rpm = hp_wmi_get_fan_speed(channel);
         if (rpm >= 0)
           priv->pwm = rpm_to_pwm(rpm / 100, priv);
       }

--- a/hp-wmi.c
+++ b/hp-wmi.c
@@ -626,7 +626,7 @@ enum pwm_modes {
 struct hp_wmi_hwmon_priv {
   u8 min_rpm;
   u8 max_rpm;
-  u8 gpu_delta;
+  int gpu_delta;
   u8 mode;
   u8 pwm;
   struct delayed_work keep_alive_dwork;
@@ -976,8 +976,10 @@ static int hp_wmi_fan_speed_set(struct hp_wmi_hwmon_priv *priv, u8 speed) {
     return ret;
   ret = hp_wmi_perform_query(HPWMI_VICTUS_S_FAN_SPEED_SET_QUERY, HPWMI_GM,
                              &fan_speed, sizeof(fan_speed), 0);
+  if (ret)
+    return ret < 0 ? ret : -EINVAL;
 
-  return ret;
+  return 0;
 }
 
 static int hp_wmi_fan_speed_reset(struct hp_wmi_hwmon_priv *priv) {
@@ -2512,7 +2514,7 @@ static int hp_wmi_hwmon_read(struct device *dev, enum hwmon_sensor_types type,
         rpm = hp_wmi_get_fan_speed_victus_s(channel);
         if (rpm < 0)
           return rpm;
-        *val = rpm_to_pwm(rpm, priv);
+        *val = rpm_to_pwm(rpm / 100, priv);
       } else {
         /* Fallback: return cached value for legacy OMENs */
         *val = priv->pwm;
@@ -2611,7 +2613,8 @@ static void hp_wmi_hwmon_keep_alive_handler(struct work_struct *work) {
 static int hp_wmi_setup_fan_settings(struct hp_wmi_hwmon_priv *priv) {
   u8 fan_data[128] = {0};
   struct victus_s_fan_table *fan_table;
-  u8 min_rpm, max_rpm, gpu_delta;
+  u8 min_rpm, max_rpm;
+  int gpu_delta;
   int ret;
   int max_val = 0;
 
@@ -2649,8 +2652,17 @@ static int hp_wmi_setup_fan_settings(struct hp_wmi_hwmon_priv *priv) {
   }
 
   min_rpm = fan_table->entries[0].cpu_rpm;
-  max_rpm = fan_table->entries[fan_table->header.num_entries - 1].cpu_rpm;
+  /*
+   * The table can be zero-padded (e.g. 8D26 declares 12 entries but
+   * ships 11) - take the max over real entries, not the last slot.
+   */
+  max_rpm = 0;
+  for (int i = 0; i < fan_table->header.num_entries; i++)
+    if (fan_table->entries[i].cpu_rpm > max_rpm)
+      max_rpm = fan_table->entries[i].cpu_rpm;
   gpu_delta = fan_table->entries[0].gpu_rpm - fan_table->entries[0].cpu_rpm;
+  if (min_rpm == 0 || max_rpm == 0)
+    return 0; /* garbage table - keep defaults */
   priv->min_rpm = min_rpm;
   priv->max_rpm = max_rpm;
   priv->gpu_delta = gpu_delta;

--- a/omen_logic.py
+++ b/omen_logic.py
@@ -56,7 +56,8 @@ SUPPORTED_BOARDS = {
     
     "88F8", "8A25",
     "8BAB", "8BBE", "8BCA", "8BD4", "8BD5", "8C76", "8C77", "8C78", "8BCD",
-    "8C4D", "8C99", "8C9C", "8D41", "8D87", "8A44", "8A4D", "8C58", "8BA9"
+    "8C4D", "8C99", "8C9C", "8D41", "8D87", "8A44", "8A4D", "8C58", "8BA9",
+    "8D26"
 }
 
 POSSIBLY_SUPPPORTED_OMEN_BOARDS = {


### PR DESCRIPTION
Closes #23 — full analysis and evidence there.

Commit 1 fixes four regressions relative to current upstream hp-wmi that make manual fan control a silent no-op on boards whose GPU fan runs slower than the CPU fan or whose fan table is zero-padded: unsigned gpu_delta underflow, max_rpm read from a padding row, missing /100 in pwm1 readback, and positive BIOS error codes reported as success.

Commit 2 adds board 8D26 (OMEN 16-ap0xxx, 2025) using the same params upstream chose for it, plus a legacy fan-speed query fallback because the victus_s query reports zeros on this board.

Verified on hardware (8D26, BIOS F.08): profiles work, commanded speeds 1000-4800 rpm track exactly on the tach, and a fan curve service has been running on this configuration all evening. Additional EC behavior notes for this generation (last-speed latch, sub-1000rpm stall protection) are in #23.