### PR TITLE
Fix build on Debian/Ubuntu HWE kernels

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,6 +57,7 @@ check-env:
 .PHONY: omen_pp_compat.h
 omen_pp_compat.h:
 	@PP_HDR=$$(find $(KERNEL_BUILD) /usr/src/linux-headers-* /usr/src/kernels/* \
+		/usr/src/linux-*-headers-* \
 		-name platform_profile.h -path "*/linux/platform_profile.h" \
 		2>/dev/null | head -1); \
 	if [ -z "$$PP_HDR" ]; then \

--- a/hp-wmi.c
+++ b/hp-wmi.c
@@ -40,6 +40,15 @@
 #include "omen_pp_compat.h"
 
 /*
+ * ACPI_AC_CLASS is not exported by the kernel headers shipped with current
+ * Debian/Ubuntu HWE kernels; the upstream in-tree hp-wmi.c carries a local
+ * definition for the same reason. Guarded so kernels that do provide it win.
+ */
+#ifndef ACPI_AC_CLASS
+#define ACPI_AC_CLASS "ac_adapter"
+#endif
+
+/*
  * Platform profile API compatibility shim.
  *
  * The API was redesigned in kernel 6.14; this driver targets the new form.

--- a/hp-wmi.c.orig
+++ b/hp-wmi.c.orig
@@ -40,6 +40,15 @@
 #include "omen_pp_compat.h"
 
 /*
+ * ACPI_AC_CLASS is not exported by the kernel headers shipped with current
+ * Debian/Ubuntu HWE kernels; the upstream in-tree hp-wmi.c carries a local
+ * definition for the same reason. Guarded so kernels that do provide it win.
+ */
+#ifndef ACPI_AC_CLASS
+#define ACPI_AC_CLASS "ac_adapter"
+#endif
+
+/*
  * Platform profile API compatibility shim.
  *
  * The API was redesigned in kernel 6.14; this driver targets the new form.


### PR DESCRIPTION

The module currently fails to build on Ubuntu 24.04 with an HWE kernel
(7.0.0-28-generic). Two independent causes:

1. **`ACPI_AC_CLASS` is undefined.** No header in these kernel trees provides
   it; the in-tree `hp-wmi.c` defines it locally for the same reason. This PR
   adds a guarded local definition after the include block, so kernels whose
   headers do provide it are unaffected:

   ```c
   #ifndef ACPI_AC_CLASS
   #define ACPI_AC_CLASS "ac_adapter"
   #endif
   ```

2. **`omen_pp_compat.h` generation cannot find `platform_profile.h`.** Ubuntu
   installs HWE headers under `/usr/src/linux-hwe-<ver>-headers-*`, which the
   existing find globs miss. Added a single `/usr/src/linux-*-headers-*` glob,
   which covers HWE and other Debian-style flavored header trees.

Both `hp-wmi.c` and `hp-wmi.c.orig` carry the change so it survives
`_patch_driver_source()` regeneration.

## Tested by

- building `hp-wmi.ko` against Ubuntu 24.04 HWE headers (kernel
  7.0.0-28-generic, board 8BB3) — fails without this change with
  `error: 'ACPI_AC_CLASS' undeclared`, builds clean with it
- installing via `install_driver.sh` with Secure Boot enabled (DKMS signs the
  module via the shim MOK key automatically)
- loading and operating the driver; no behavior change on kernels whose
  headers already define `ACPI_AC_CLASS` (the `#ifndef` short-circuits)

This work was done with Claude Code (Opus 5 and Fable 5), on behalf of Vlad Marinkovic
(@vlad-marinkovic), who operates the test hardware and is available for
follow-up testing.
