### PR TITLE
Add HP OMEN Transcend 16 8BB3 fan support

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ The patch can be installed on versions before `6.20` as well.
 This program also includes a modification that sets the max speed according to calibration if the query to get the Max RPM fails for your device.
 ## Tested Hardware
 
-*   **Models:** HP OMEN MAX 16-AH0xxxNT (8D41), HP OMEN Transcend 16-u1xxx (8C4D), OMEN by HP Gaming Laptop 16-xf0xxx (8BCA), HP Victus 16 s1xxx (8C9C)
-*   **OS:** Arch Linux 6.18, 6.19, 7.0, 7.1
+*   **Models:** HP OMEN MAX 16-AH0xxxNT (8D41), HP OMEN Transcend 16-u1xxx (8C4D), OMEN by HP Gaming Laptop 16-xf0xxx (8BCA), HP Victus 16 s1xxx (8C9C), HP OMEN Transcend 16-u0xxx (8BB3)
+*   **OS:** Arch Linux 6.18, 6.19, 7.0, 7.1; Ubuntu 24.04 (HWE 7.0)
 
 > Would you like to add your model here? Create an issue with the "Tested Hardware" label and include these after successfully installing the patch and using the tool:
 > * Your laptop's board id (you can find it in /sys/class/dmi/id/board_name)

--- a/hp-wmi.c
+++ b/hp-wmi.c
@@ -363,6 +363,10 @@ static const struct dmi_system_id victus_s_thermal_profile_boards[] __initconst 
 		.driver_data = (void *)&victus_s_thermal_params,
 	},
 	{
+		.matches = { DMI_MATCH(DMI_BOARD_NAME, "8BB3") },
+		.driver_data = (void *)&omen_v1_no_ec_thermal_params,
+	},
+	{
 		.matches = { DMI_MATCH(DMI_BOARD_NAME, "8BBE") },
 		.driver_data = (void *)&victus_s_thermal_params,
 	},

--- a/hp-wmi.c.orig
+++ b/hp-wmi.c.orig
@@ -363,6 +363,10 @@ static const struct dmi_system_id victus_s_thermal_profile_boards[] __initconst 
 		.driver_data = (void *)&victus_s_thermal_params,
 	},
 	{
+		.matches = { DMI_MATCH(DMI_BOARD_NAME, "8BB3") },
+		.driver_data = (void *)&omen_v1_no_ec_thermal_params,
+	},
+	{
 		.matches = { DMI_MATCH(DMI_BOARD_NAME, "8BBE") },
 		.driver_data = (void *)&victus_s_thermal_params,
 	},

--- a/omen_logic.py
+++ b/omen_logic.py
@@ -67,7 +67,7 @@ SUPPORTED_BOARDS = {
     
     "88F8", "8A25",
     "8BAB", "8BBE", "8BCA", "8BD4", "8BD5", "8C76", "8C77", "8C78", "8BCD",
-    "8C4D", "8C99", "8C9C", "8D26", "8D41", "8D87", "8A44", "8A4D", "8C58", "8BA9", "8BAA"
+    "8BB3", "8C4D", "8C99", "8C9C", "8D26", "8D41", "8D87", "8A44", "8A4D", "8C58", "8BA9", "8BAA"
 }
 
 POSSIBLY_SUPPPORTED_OMEN_BOARDS = {
@@ -80,7 +80,7 @@ POSSIBLY_SUPPPORTED_OMEN_BOARDS = {
     "8912", "8917", "8918", "8A97", "8A96", "8D2C", "8949", "8A98", "894A",
     "8B1D", "89EB", "8A4C", "8A4D", "8A4E", "8A40", "8A41", "8A42", "8A43",
     "8A44", "8BA8", "8BA9", "8BAA", "8BAC", "8C76", "8C77", "8C78",
-    "8BCA", "8BCB", "8BCF", "8C9B", "8BB3", "8BB4", "8C4E",
+    "8BCA", "8BCB", "8BCF", "8C9B", "8BB4", "8C4E",
     "8C58", "8C75", "8C74", "8C73", "8CC1", "8CC0", "8CF1", "8CF2", "8CF3",
     "8CF4", "8D2F"
 }


### PR DESCRIPTION

Tested on an HP OMEN Transcend 16-u0xxx, board id `8BB3`, Ubuntu 24.04,
kernel 7.0.0-28-generic. `8BB3` was already listed in
`POSSIBLY_SUPPPORTED_OMEN_BOARDS`; per the workflow described in issue #21,
here is a tested profile assignment so other 8BB3 users no longer need a
profile override.

## Why `omen_v1_no_ec_thermal_params`

Neither EC thermal-profile offset holds a valid profile byte on this board,
so the two readback-capable profiles cannot work:

- `0x59` (Victus S offset) reads `0x01`
- `0x95` (legacy OMEN offset) reads `0x43` — ASCII data from a part-number
  string that happens to live there

Valid profile bytes would be `0x30`/`0x31`/`0x50`. `omen_v1_no_ec_thermal_params`
skips EC readback entirely, which is the same treatment `8D41` and `8D87`
already receive in this table.

Two further data points from this board, for the record:

- `HPWMI_FAN_SPEED_GET_QUERY` (0x11) is a BIOS stub here, while the Victus S
  fan-speed queries return live, independent readings for both fans — so the
  Victus S path is also what makes fan telemetry work.
- With this entry, `platform_profile_victus_s_set_ec()` configures the GPU
  power modes at profile setup: sustained GPU power measured on this machine
  rises from a hard 80 W software cap to ~93 W at 2415-2430 MHz (RTX 4070 Laptop,
  Dynamic Boost via `nvidia-powerd` active). Without the entry the cap stays
  at 80 W. Mentioning it because it makes this a functional gain for 8BB3
  owners beyond fan control.

## Changes (follows the shape of #20)

- `hp-wmi.c` **and** `hp-wmi.c.orig`: `8BB3` →
  `victus_s_thermal_profile_boards[]` with `omen_v1_no_ec_thermal_params`
  (both files, so the entry survives `_patch_driver_source()` regeneration)
- `omen_logic.py`: `8BB3` moved from `POSSIBLY_SUPPPORTED_OMEN_BOARDS` to
  `SUPPORTED_BOARDS`
- `README.md`: Tested Hardware entry

## Tested by

- building against Ubuntu 24.04 HWE headers and loading (Secure Boot enabled,
  DKMS-signed). Note: building on Debian/Ubuntu HWE also needs the separate
  build fix in the `fix-hwe-build` PR; the two changes are otherwise
  independent.
- `platform_profile` registers with low-power / balanced / performance
- hwmon exposes `pwm1`, `pwm1_enable`, and both `fan1_input`/`fan2_input`
  with live readings
- manual PWM sweep, 25 s settle per point (BIOS "Fan Always On" disabled):
  pwm 80/120/170/215/255 → 1600/2500/3600/4600/5600 RPM, both fans, ascending
  equal to descending within 100 RPM. Telemetry validated as true tachometry by
  step response: after pwm 80→255 the reading ramps 1600→1700→3600→5300→5600
  over ~25 s rather than jumping; `pwm1_enable=2` returns the fan to EC
  automatic control cleanly
- `install_driver.sh` end-to-end, and `_patch_driver_source()` regeneration
  verified to preserve the entry
- multi-hour mixed CPU+GPU load runs under a userspace fan curve driving
  `pwm1`, no EC fallback events

Not tested: anything requiring a second 8BB3 unit or other OMEN variants; one
machine only.

This work was done with Claude Code (Opus 5 and Fable 5), on behalf of Vlad Marinkovic
(@vlad-marinkovic), who operates the test hardware and is available for
follow-up testing.
